### PR TITLE
Magz/replace tabs with router outlets

### DIFF
--- a/src/app/detail/detail-routing.module.ts
+++ b/src/app/detail/detail-routing.module.ts
@@ -1,40 +1,51 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import {DetailComponent} from "./detail.component";
+import { DetailComponent } from './detail.component';
 
 const routes: Routes = [
   {
-    path: '',
+    path: ':id',
     component: DetailComponent,
     children: [
       {
-        path: 'summary',
+        path: '',
         children: [
           {
-            path: '',
-            loadChildren: () => import('./summary/summary.module').then((m) => m.SummaryModule),
+            path: 'summary',
+            children: [
+              {
+                path: '',
+                loadChildren: () =>
+                  import('./summary/summary.module').then(
+                    (m) => m.SummaryModule
+                  ),
+              },
+            ],
+          },
+          {
+            path: 'hardware',
+            children: [
+              {
+                path: '',
+                loadChildren: () =>
+                  import('./hardware/hardware.module').then(
+                    (m) => m.HardwareModule
+                  ),
+              },
+            ],
+          },
+          {
+            path: '**',
+            redirectTo: 'summary',
           },
         ],
       },
-      {
-        path: 'hardware',
-        children: [
-          {
-            path: '',
-            loadChildren: () => import('./hardware/hardware.module').then((m) => m.HardwareModule),
-          },
-        ],
-      },
-      {
-        path: '**',
-        redirectTo: 'summary'
-      }
     ],
   },
 ];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],
-  exports: [RouterModule]
+  exports: [RouterModule],
 })
 export class DetailRoutingModule {}

--- a/src/app/detail/detail.component.html
+++ b/src/app/detail/detail.component.html
@@ -1,6 +1,6 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>Card {{id}} Name</ion-title>
+    <ion-title>Card {{ id }} Name</ion-title>
     <ion-buttons slot="start">
       <ion-back-button defaultHref="/"></ion-back-button>
     </ion-buttons>
@@ -8,15 +8,14 @@
 </ion-header>
 
 <ion-content>
-  <ion-tabs>
-    <ion-tab-bar slot="top">
-      <ion-tab-button tab="summary">
-        <ion-label>Summary</ion-label>
-      </ion-tab-button>
-      <ion-tab-button tab="hardware">
-        <ion-label>Hardware</ion-label>
-      </ion-tab-button>
-    </ion-tab-bar>
-  </ion-tabs>
+  <ion-segment value="buttons">
+    <ion-segment-button value="summary" routerLink="summary">
+      <ion-label>Summary</ion-label>
+    </ion-segment-button>
+    <ion-segment-button value="hardware" routerLink="hardware">
+      <ion-label>Hardware</ion-label>
+    </ion-segment-button>
+  </ion-segment>
 
+  <router-outlet />
 </ion-content>

--- a/src/app/detail/summary/summary.component.ts
+++ b/src/app/detail/summary/summary.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ViewWillEnter } from '@ionic/angular';
 
@@ -7,11 +7,11 @@ import { ViewWillEnter } from '@ionic/angular';
   templateUrl: './summary.component.html',
   styleUrls: ['./summary.component.scss'],
 })
-export class SummaryComponent implements ViewWillEnter {
+export class SummaryComponent implements OnInit {
   id: string | null = '';
   constructor(private route: ActivatedRoute) {}
 
-  ionViewWillEnter() {
+  ngOnInit() {
     console.log(
       'summary: this.route.snapshot.parent.parent.parent.paramMap: ',
       this.route.snapshot.parent?.parent?.parent?.paramMap

--- a/src/app/tab1/tab1-routing.module.ts
+++ b/src/app/tab1/tab1-routing.module.ts
@@ -32,7 +32,7 @@ const routes: Routes = [
     ],
   },
   {
-    path: 'detail/:id',
+    path: 'detail',
     loadChildren: () =>
       import('../detail/detail.module').then((m) => m.DetailPageModule),
   },

--- a/src/app/tab1/tab1.page.html
+++ b/src/app/tab1/tab1.page.html
@@ -5,35 +5,17 @@
 </ion-header>
 
 <ion-content>
-  <!--  <ion-header collapse="condense">-->
-  <!--    <ion-toolbar>-->
-  <!--      <ion-title size="large">Tab 1</ion-title>-->
-  <!--    </ion-toolbar>-->
-  <!--  </ion-header>-->
-  <!-- <ion-segment value="buttons">
-    <ion-segment-button value="assets">
+  <ion-segment value="buttons">
+    <ion-segment-button value="assets" routerLink="assets">
       <ion-label>Assets</ion-label>
     </ion-segment-button>
-    <ion-segment-button value="advisories">
+    <ion-segment-button value="advisories" routerLink="advisories">
       <ion-label>Advisories</ion-label>
     </ion-segment-button>
-    <ion-segment-button value="cases">
+    <ion-segment-button value="cases" routerLink="cases">
       <ion-label>Cases</ion-label>
     </ion-segment-button>
-  </ion-segment> -->
+  </ion-segment>
 
-  <ion-tabs>
-    <ion-tab-bar slot="top">
-      <ion-tab-button tab="assets" href="assets">
-        <ion-label>Assets</ion-label>
-      </ion-tab-button>
-      <ion-tab-button tab="advisories" href="advisories">
-        <ion-label>Advisories</ion-label>
-      </ion-tab-button>
-
-      <ion-tab-button tab="cases" href="cases">
-        <ion-label>Cases</ion-label>
-      </ion-tab-button>
-    </ion-tab-bar>
-  </ion-tabs>
+  <router-outlet />
 </ion-content>


### PR DESCRIPTION
Replaces ion-tabs with ion-segment + router-outlet.
This matches our Mobile implementation, and the POC shows that we can route to N levels of Details and the back button works as expected.